### PR TITLE
Use new features in TemplateScript 2.0

### DIFF
--- a/src/TemplateScript.js
+++ b/src/TemplateScript.js
@@ -15,6 +15,16 @@
 		oldText = null,
 		list = [];
 
+	function showDiff() {
+		var $button = $('#wpDiffLive');
+		// FIXME: Only do a diff if the text was changed
+		// Maybe use bit operators: MINOR & DIFF & SAVE & ...
+		if (!$button.length) {
+			$button = $('#wpDiff');
+		}
+		$button.click();
+	}
+
 	function regex(editor, regexList, summary, pos ) {
 		var text = editor.get(),
 			i, l, rule;
@@ -268,7 +278,7 @@
 				find: reOldSign,
 				replace: mw.user.options.get( 'nickname' )
 			}], 'Fixing links (my user account was renamed)' );
-			editor.clickDiff();
+			showDiff();
 		} );
 	}
 
@@ -694,7 +704,7 @@
 				''
 			)
 		);
-		editor.clickDiff();
+		showDiff();
 	}
 
 	/** Latex2wiki **
@@ -1130,7 +1140,7 @@
 		default:
 			fixObsoleteHTML(c);
 		}
-		editor.clickDiff();
+		showDiff();
 	}
 
 	function loadMyRegexTools() {

--- a/src/TemplateScript.js
+++ b/src/TemplateScript.js
@@ -15,16 +15,6 @@
 		oldText = null,
 		list = [];
 
-	function showDiff() {
-		var $button = $('#wpDiffLive');
-		// FIXME: Only do a diff if the text was changed
-		// Maybe use bit operators: MINOR & DIFF & SAVE & ...
-		if (!$button.length) {
-			$button = $('#wpDiff');
-		}
-		$button.click();
-	}
-
 	function regex(editor, regexList, summary, pos ) {
 		var text = editor.get(),
 			i, l, rule;
@@ -37,7 +27,7 @@
 			if ( summary ) {
 				switch( pos ) {
 					case 'before':
-						$( '#wpSummary:first' ).val(function(i, val) { return summary + val; });
+						editor.for( '#wpSummary' ).prepend( summary );
 						break;
 
 					case 'replace':
@@ -278,7 +268,7 @@
 				find: reOldSign,
 				replace: mw.user.options.get( 'nickname' )
 			}], 'Fixing links (my user account was renamed)' );
-			showDiff();
+			editor.clickDiff();
 		} );
 	}
 
@@ -704,7 +694,7 @@
 				''
 			)
 		);
-		showDiff.click();
+		editor.clickDiff();
 	}
 
 	/** Latex2wiki **
@@ -1140,7 +1130,7 @@
 		default:
 			fixObsoleteHTML(c);
 		}
-		showDiff();
+		editor.clickDiff();
 	}
 
 	function loadMyRegexTools() {


### PR DESCRIPTION
This commit uses new features in TemplateScript 2.0 to simplify a few bits of the code.

The new code is _almost_ equivalent, except that your code looked for a diff button matching `$('#wpDiffLive')` and TemplateScript doesn't. I couldn't find any information about that selector; there's a live diff feature on [test.wikipedia.org](//test.wikipedia.org), but it uses the normal `$('#wpDiff')` button. If it's still relevant on some wikis, I can add support directly in TemplateScript.
