### PR TITLE
Update to TemplateScript 2.0.2

### DIFF
--- a/src/TemplateScript.js
+++ b/src/TemplateScript.js
@@ -37,7 +37,7 @@
 			if ( summary ) {
 				switch( pos ) {
 					case 'before':
-						editor['for']( '#wpSummary' ).prepend( summary );
+						editor.forField( '#wpSummary' ).prepend( summary );
 						break;
 
 					case 'replace':


### PR DESCRIPTION
TemplateScript's new `.for()` method was renamed to `forField()` due to a ResourceLoader issue (see [#68](https://github.com/Pathoschild/Wikimedia-contrib/issues/68)). This commit updates usage.
